### PR TITLE
docs: fix missing space in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When that happens, they can update the implementations appropriately.
 ### Installation
 
 ```
-python3 -mpip install ethspecify
+python3 -m pip install ethspecify
 ```
 
 ### Adding Spec Tags


### PR DESCRIPTION
Typo in the install instructions - there was no space between `-m` and `pip`, which could cause issues when copying the command.
Fixed that.