### PR TITLE
Use ethereum repository URLs

### DIFF
--- a/ethspecify/core.py
+++ b/ethspecify/core.py
@@ -237,7 +237,7 @@ def diff(a_name, a_content, b_name, b_content):
 
 @functools.lru_cache()
 def get_pyspec(version="nightly"):
-    url = f"https://raw.githubusercontent.com/jtraglia/ethspecify/main/pyspec/{version}/pyspec.json"
+    url = f"https://raw.githubusercontent.com/ethereum/ethspecify/main/pyspec/{version}/pyspec.json"
     response = requests.get(url)
     response.raise_for_status()
     return response.json()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Justin Traglia",
     author_email="jtraglia@pm.me",
-    url="https://github.com/jtraglia/ethspecify",
+    url="https://github.com/ethereum/ethspecify",
     packages=find_packages(),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- Update the package metadata URL to the canonical `ethereum/ethspecify` repository.
- Fetch bundled pyspec JSON from the canonical `ethereum/ethspecify` raw GitHub path instead of the pre-transfer owner path.

## Validation
- `python3 -m compileall -q ethspecify`
- Confirmed `setup.py` metadata URL resolves to `https://github.com/ethereum/ethspecify`
- Confirmed no remaining `jtraglia/ethspecify` repository references outside generated `pyspec/` data